### PR TITLE
Remove captcha

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -33,7 +33,6 @@
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-config" content="/icons/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
-	<script src='https://www.google.com/recaptcha/api.js'></script>
 </head>
 
 <body>
@@ -112,7 +111,6 @@
 					<section class="6u 12u(narrower)">
 						<h3>Get In Touch</h3>
 						<form action="https://formspree.io/moqlzbwv" method="POST" id="custom-form">
-							<div class="g-recaptcha" data-sitekey="6LcvawcTAAAAAJ921c96oeiEDeucunvF0ylgv8P1"></div>
 							<input type="hidden" name="_next" value="thanks.html" />
 							<input type="text" name="_gotcha" style="display:none" />
 							<div class="row 50%">


### PR DESCRIPTION
Trying to curb the spam...

So right now, there's a captcha on the form, added by @aswerdlow935. That captcha doesn't do anything because of no server-side verification happening.

Formspree has a Captcha option where it redirects to a captcha which seems like a safer bet -- minor inconvenience for legitimate users, major preventer of spam, though.

Until we remove the actual captcha from the form, Formspree runs into an error where the captcha on the form doesn't match a token we gave them. Setting it up without a redirect is _possible_ but not worth the effort imo. 

Doing this for now as an in between step to test if having the captcha on will really stop the spam. If it does, someone else is more than welcome to implement a prettier version.